### PR TITLE
Fix Japanese full view count parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Version 3.1.20
+
+**Fixed**
+
+- Japanese full view counts such as "1526 回視聴" are now recognized by the Minimum Views Filter, so videos below the configured threshold are hidden correctly
+
 ### Version 3.1.19
 
 **Fixed**

--- a/content/parsers.js
+++ b/content/parsers.js
@@ -29,6 +29,8 @@ const SUFFIX_REGEX = new RegExp(
   'i',
 );
 
+const VIEW_COUNT_LABELS = new Set(['回視聴']);
+
 function extractNumberAndSuffix(input) {
   const s = String(input)
     .trim()
@@ -106,6 +108,10 @@ function extractViewCount(text) {
 
   if (!remainder) {
     return { views: base, confidence: 'low' };
+  }
+
+  if (VIEW_COUNT_LABELS.has(remainder)) {
+    return { views: base, confidence: 'high' };
   }
 
   const words = remainder.split(/\s+/).filter(Boolean);

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Youtube Hider: hide watched videos, Shorts and low views",
     "short_name": "YouTube Hider",
-    "version": "3.1.19",
+    "version": "3.1.20",
     "description": "Hides already watched videos from YouTube, as well as low views videos and remove Shorts.",
     "icons": {
         "16": "assets/icons/YT Hider icon v6.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-hider-extension",
-  "version": "3.1.19",
+  "version": "3.1.20",
   "description": "Chrome extension that hides YouTube videos by view count, upload age and more.",
   "private": true,
   "type": "commonjs",

--- a/tests/parsers.test.js
+++ b/tests/parsers.test.js
@@ -35,6 +35,23 @@ test('with a 100-view threshold, a 98k video is no longer hidden', () => {
   assert.ok(views('98,756 views') >= THRESHOLD);
 });
 
+test('regression: Japanese full-form view counts use the exact YouTube label', () => {
+  assert.equal(views('1526 回視聴'), 1526);
+  assert.equal(views('9,999 回視聴'), 9999);
+  assert.equal(views('10,000 回視聴'), 10000);
+  assert.equal(views('1万 回視聴'), 10000);
+  assert.equal(views('9.5万 回視聴'), 95000);
+
+  assert.ok(Number.isNaN(views('1526 日前')));
+  assert.ok(Number.isNaN(views('1526 コメント')));
+});
+
+test('with a 10k-view threshold, Japanese full-form counts filter correctly', () => {
+  const THRESHOLD = 10000;
+  assert.ok(views('1526 回視聴') < THRESHOLD);
+  assert.ok(views('9.5万 回視聴') >= THRESHOLD);
+});
+
 test('abbreviated formats keep working (must not regress)', () => {
   assert.equal(views('98K views'), 98000);
   assert.equal(views('1.2M views'), 1200000);


### PR DESCRIPTION
## Problem

Japanese YouTube can render full view counts such as `1526 回視聴`. The parser currently rejects the Japanese remainder and returns `NaN`, so the Minimum Views Filter does not hide these videos.

## Root cause

The suffixless full-number fallback only accepts a single Latin-script remainder. The exact Japanese view-count label `回視聴` therefore falls through to `NaN`.

## Fix

Recognize the exact Japanese YouTube view-count label `回視聴` as a valid high-confidence label before the existing Latin-script fallback. Other Japanese text remains rejected.

## Tests

Added parser regression coverage for:

- `1526 回視聴` -> 1,526 views
- `9,999 回視聴` -> 9,999 views
- `10,000 回視聴` -> 10,000 views
- `1万 回視聴` -> 10,000 views
- `9.5万 回視聴` -> 95,000 views
- `1526 日前` -> `NaN`
- `1526 コメント` -> `NaN`
- Minimum Views threshold behavior at 10,000 views

`npm test` passes all 11 tests.

## Version

Bumped the patch version from `3.1.19` to `3.1.20` in `manifest.json` and `package.json`, with a matching changelog entry.